### PR TITLE
Allow to pass a cdn data object in options

### DIFF
--- a/googlecdn.js
+++ b/googlecdn.js
@@ -39,7 +39,7 @@ module.exports = function cdnify(content, bowerJson, options, callback) {
   options.componentsPath = options.componentsPath || 'bower_components';
 
   var cdn = options.cdn || 'google';
-  var cdnData = data[cdn];
+  var cdnData = (typeof(cdn) === 'object' ? cdn : data[cdn]);
 
   if (!cdnData) {
     return callback(new Error('CDN ' + cdn + ' is not supported.'));

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,18 @@ The library versions are inferred from the `bowerJson`.
   - `componentsPath`: defaults to `bower_components`, the path you specify in
     your script tags to the components directory.
   - `cdn`: defaults to `google`. CDN you want to use. Possible values: `google`,
-    `cdnjs`
+    `cdnjs` or object of the following format:
+
+  ```javascript
+  {
+    jquery: {
+      versions: ['2.0.3', '2.0.2', '2.0.1', '2.0.0'],
+      url: function (version) {
+        return '//my.own.cdn/libs/jquery/' + version + '/jquery.min.js';
+      }
+    }
+  }
+  ```
 
 ## Grunt
 

--- a/test.js
+++ b/test.js
@@ -80,6 +80,33 @@ describe('google-cdn', function () {
     });
   });
 
+  it('should support cdn object', function (cb) {
+    var source = '<script src="bower_components/jquery/jquery.js"></script>';
+    var bowerConfig = {
+      dependencies: { 'jquery': '~2.0.1' }
+    };
+
+    this.mainPath = 'jquery/jquery.js';
+
+    var cdnObject = {
+      jquery: {
+        versions: ['2.0.3', '2.0.2', '2.0.1', '2.0.0'],
+        url: function (version) {
+          return '//my.own.cdn/libs/jquery/' + version + '/jquery.min.js';
+        }
+      }
+    };
+
+    this.googlecdn(source, bowerConfig, { cdn: cdnObject }, function (err, result) {
+      if (err) {
+        return cb(err);
+      }
+
+      assert.equal(result, '<script src="//my.own.cdn/libs/jquery/2.0.3/jquery.min.js"></script>');
+      cb();
+    });
+  });
+
   it('should strip leading slashes', function (cb) {
     var source = '<script src="/bower_components/jquery/jquery.js"></script>';
     var bowerConfig = {


### PR DESCRIPTION
I think that the correct way to use google-cdn is not to store all the "cdn data" in lib/data.js.
Instead ppl should be able to create their own "cdn data" node modules and google-cdn should accept those in the options param. This will make the "cdn data" much more easily maintained and will also provide a very easy solution for ppl like me who would like to use their own company cdn for their apps.

Also, the name of this project needs to change :)
