### PR TITLE
feat(cdnjs): check for matching bower packages by removing `.js` from…

### DIFF
--- a/googlecdn.js
+++ b/googlecdn.js
@@ -17,7 +17,7 @@ var bowerUtil = require('./util/bower');
 function getVersionStr(bowerJson, name) {
   var versionStr;
   if (bowerJson.dependencies) {
-    versionStr = bowerJson.dependencies[name];
+    versionStr = bowerJson.dependencies[name] || bowerJson.dependencies[name.replace(/\.js$/,'')];
   }
 
   if (!versionStr && bowerJson.devDependencies && bowerJson.devDependencies[name]) {

--- a/test.js
+++ b/test.js
@@ -68,6 +68,24 @@ describe('google-cdn', function () {
     });
   });
 
+  it('should replace lodash, even though bower and cdnjs use different names', function (cb) {
+    var source = '<script src="bower_components/lodash/dist/lodash.compat.js"></script>';
+    var bowerConfig = {
+      dependencies: { lodash: '~3.9.0' }
+    };
+
+    this.mainPath = 'lodash/dist/lodash.compat.js';
+
+    this.googlecdn(source, bowerConfig, { cdn: 'cdnjs' }, function (err, result) {
+      if (err) {
+        return cb(err);
+      }
+
+      assert.equal(result, '<script src="//cdnjs.cloudflare.com/ajax/libs/lodash.js/3.9.3/lodash.min.js"></script>');
+      cb();
+    });
+  });
+
   it('should throw without bowerJson', function () {
     var source = '<script src="bower_components/jquery-ui/ui/jquery-ui.js"></script>';
     var bowerConfig = null;


### PR DESCRIPTION
… the name

packages like `lodash` are not cdnified because bower and cdnjs don't always
use the same package names. This update will attempt to find a matching bower
package name by removing `.js` from the cdnjs package name