### PR TITLE
feat(cdn): accept array of CDN hosts

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "bower": "^1.4.1",
     "cdnjs-cdn-data": "~0.1.0",
     "debug": "^2.1.0",
+    "escape-regexp": "0.0.1",
     "google-cdn-data": "~0.1.0",
     "regexp-quote": "0.0.0",
     "semver": "^5.0.1"


### PR DESCRIPTION
allow users to specify an arry of CDN hosts to check for matches, e.g.
`['google', 'cdnjs']`. Hosts will be checked in order.  Does not change
the current default behaviour.